### PR TITLE
#1473222 Allow managers to deactivate and delete trainers. 

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -38,7 +38,7 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -43,6 +43,9 @@
                  <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
              {% elif perms.gym.manage_gym and current_user.perms.gym_trainer %}
                  <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+            {% elif perms.gym.manage_gyms %}
+                {{current_user.obj}}
+            {% endif %}
              {% else %}
                  {{current_user.obj}}
              {% endif %}

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -14,7 +14,7 @@
 
 
 {% block content %}
-{% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+{% if perms.gym.manage_gym or perms.gym.gym_trainer or perms.gym.manage_gyms %}
     {% include 'gym/partial_user_list.html' %}
 {% endif %}
 
@@ -26,6 +26,7 @@
     <th style="width: 10%;">{% trans "ID" %}</th>
     <th style="width: 40%;">{% trans "Username" %}</th>
     <th>{% trans "Name" %}</th>
+     <th>{% trans "Status" %}</th>
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
         <th style="text-align: right;">{% trans "Roles" %}</th>
     {% endif %}
@@ -34,35 +35,45 @@
 <tbody>
 {% for current_user in object_list.admins %}
 <tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+         <td>
+             {{current_user.obj.pk}}
+         </td>
+        <td>
+             {% if perms.gym.manage_gyms and not current_user.perms.manage_gyms %}
+                 <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+             {% elif perms.gym.manage_gym and current_user.perms.gym_trainer %}
+                 <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+             {% else %}
+                 {{current_user.obj}}
+             {% endif %}
+             {% if current_user.perms.gym_trainer %}
+                 <span class="label label-primary">{% trans "Trainer" %}</span>
+             {% endif %}
+             {% if current_user.perms.manage_gym %}
+                <span class="label label-primary">{% trans "Gym manager" %}</span>
+             {% endif %}
+                         {% if current_user.perms.manage_gyms %}
+                 <span class="label label-primary">{% trans "General manager" %}</span>
+             {% endif %}
+         </td>
+         <td>
+             {{current_user.obj.get_full_name}}
+         </td>
+         <td>
+            {% if current_user.is_active %}
+                {% trans "Active" %}
+            {% else %}
+                {% trans "Inactive" %}
+            {% endif %}
+        </td>
+         {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+         <td style="text-align: right;">
+             <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
+                 <span class="{% fa_class 'cog' %}"></span>
+             </a>
+         </td>
+         {% endif %}
 
-        {% if current_user.perms.gym_trainer %}
-            <span class="label label-primary">{% trans "Trainer" %}</span>
-        {% endif %}
-
-        {% if current_user.perms.manage_gym %}
-            <span class="label label-primary">{% trans "Gym manager" %}</span>
-        {% endif %}
-
-        {% if current_user.perms.manage_gyms %}
-            <span class="label label-primary">{% trans "General manager" %}</span>
-        {% endif %}
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-
-    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
-    <td style="text-align: right;">
-        <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
-            <span class="{% fa_class 'cog' %}"></span>
-        </a>
-    </td>
-    {% endif %}
 </tr>
 {% empty %}
 <tr>

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -43,9 +43,6 @@
                  <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
              {% elif perms.gym.manage_gym and current_user.perms.gym_trainer %}
                  <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-            {% elif perms.gym.manage_gyms %}
-                {{current_user.obj}}
-            {% endif %}
              {% else %}
                  {{current_user.obj}}
              {% endif %}
@@ -63,7 +60,7 @@
              {{current_user.obj.get_full_name}}
          </td>
          <td>
-            {% if current_user.is_active %}
+            {% if current_user.obj.is_active %}
                 {% trans "Active" %}
             {% else %}
                 {% trans "Inactive" %}


### PR DESCRIPTION
#### What does this PR do?
This PR adds a feature that will enable gym managers to deactivate and delete trainers.

#### Description of Task to be completed?
Currently a manager cannot delete or deactivate trainers from a gym.
They should be able to do this

#### What are the relevant pivotal tracker stories?
The pivotal tracker story for this work can be found [here](https://www.pivotaltracker.com/n/projects/2055145/stories/147322275)

### Screenshots
The screenshot below shows the initial gym administrators and trainers list.
<img width="1280" alt="initial" src="https://user-images.githubusercontent.com/26175241/28452670-6ae62d56-6dfc-11e7-8f5f-df308d9cbf13.png">

The screenshot below shows the overview page that allows the manager to delete and deactivate trainers. Clicking on the trainer's username redirects to this page.
<img width="1280" alt="settings page" src="https://user-images.githubusercontent.com/26175241/28452732-bf0553a8-6dfc-11e7-86e6-7e4569cc28df.png">

The screenshot below shows the status of the user 'trainer' after being deactivated.
<img width="1280" alt="deactivate trainer" src="https://user-images.githubusercontent.com/26175241/28452823-193ac9c0-6dfd-11e7-8572-4c675430129f.png">

The screenshot below shows successful deletion of the user 'trainer'.
<img width="1280" alt="deleted" src="https://user-images.githubusercontent.com/26175241/28452886-53ad7a80-6dfd-11e7-92ba-f9d04529805e.png">
